### PR TITLE
[ADD] Added ServerIPv4 config field.

### DIFF
--- a/context/ausf_context.go
+++ b/context/ausf_context.go
@@ -8,6 +8,7 @@ import (
 
 type AUSFContext struct {
 	NfId            string
+	ServerIPv4      string
 	GroupId         string
 	HttpIpv4Port    int
 	HttpIPv4Address string

--- a/context/ausf_context_init.go
+++ b/context/ausf_context_init.go
@@ -6,6 +6,7 @@ import (
 	"free5gc/lib/path_util"
 	"free5gc/src/ausf/factory"
 	"free5gc/src/ausf/logger"
+	"os"
 	"strconv"
 
 	"github.com/google/uuid"
@@ -24,10 +25,23 @@ func InitAusfContext(context *AUSFContext) {
 
 	configuration := config.Configuration
 	sbi := configuration.Sbi
-
+	context.ServerIPv4 = os.Getenv(configuration.ServerIPv4)
+	if context.ServerIPv4 == "" {
+		logger.InitLog.Warn("Problem parsing ServerIPv4 address from ENV Variable. Trying to parse it as string.")
+		context.ServerIPv4 = configuration.ServerIPv4
+		if context.ServerIPv4 == "" {
+			logger.InitLog.Warn("Error parsing ServerIPv4 address as string. Using the localhost address as default.")
+			context.ServerIPv4 = "127.0.0.1"
+		}
+	}
 	context.NfId = uuid.New().String()
 	context.GroupId = configuration.GroupId
-	context.NrfUri = configuration.NrfUri
+	if configuration.NrfUri != "" {
+		context.NrfUri = configuration.NrfUri
+	} else {
+		logger.InitLog.Warn("NRF Uri is empty! Using localhost as NRF IPv4 address.")
+		context.NrfUri = fmt.Sprintf("%s://%s:%d", context.UriScheme, "127.0.0.1", 29510)
+	}
 	context.UriScheme = models.UriScheme(configuration.Sbi.Scheme) // default uri scheme
 	context.HttpIPv4Address = "127.0.0.1"                          // default localhost
 	context.HttpIpv4Port = 29509                                   // default port

--- a/factory/config.go
+++ b/factory/config.go
@@ -19,6 +19,8 @@ type Info struct {
 }
 
 type Configuration struct {
+	ServerIPv4 string `yaml:"serverIPv4,omitempty"`
+
 	Sbi *Sbi `yaml:"sbi,omitempty"`
 
 	ServiceNameList []string `yaml:"serviceNameList,omitempty"`

--- a/service/init.go
+++ b/service/init.go
@@ -112,8 +112,10 @@ func (ausf *AUSF) Start() {
 
 	ausfLogPath := util.AusfLogPath
 
+	addr := fmt.Sprintf("%s:%d", self.ServerIPv4, self.HttpIpv4Port)
+
 	go handler.Handle()
-	server, err := http2_util.NewServer(":29509", ausfLogPath, router)
+	server, err := http2_util.NewServer(addr, ausfLogPath, router)
 	if server == nil {
 		initLog.Errorln("Initialize HTTP server failed: %+v", err)
 		return


### PR DESCRIPTION
The `ServerIPv4` field will be used to specify the IP where the server will start.
The difference that this field makes is that now the NFs can advertise a service IP (which is different from the NodeIP) in Kubernetes.

These modifications were tested and no compatibility issues were found.

This PR comes after the discussion here: https://github.com/free5gc/free5gc/issues/49#issuecomment-640213366