### PR TITLE
Set RAND only if AMF doesn't send it.

### DIFF
--- a/producer/ue_authentication.go
+++ b/producer/ue_authentication.go
@@ -111,7 +111,9 @@ func UeAuthPostRequestProcedure(updateAuthenticationInfo models.AuthenticationIn
 		logger.UeAuthPostLog.Warningln(ausfCurrentSupi)
 		ausfCurrentContext := ausf_context.GetAusfUeContext(ausfCurrentSupi)
 		logger.UeAuthPostLog.Warningln(ausfCurrentContext.Rand)
-		updateAuthenticationInfo.ResynchronizationInfo.Rand = ausfCurrentContext.Rand
+		if updateAuthenticationInfo.ResynchronizationInfo.Rand == "" {
+			updateAuthenticationInfo.ResynchronizationInfo.Rand = ausfCurrentContext.Rand
+		}
 		logger.UeAuthPostLog.Warningln("Rand: ", updateAuthenticationInfo.ResynchronizationInfo.Rand)
 		authInfoReq.ResynchronizationInfo = updateAuthenticationInfo.ResynchronizationInfo
 	}


### PR DESCRIPTION
The RAND in the message should be sent by AMF, AUSF needs to set it only if AMF doesn't send it.