### PR TITLE
Fix Kseaf Derived From Empty Array on DecodeString() Error

### DIFF
--- a/internal/sbi/producer/ue_authentication.go
+++ b/internal/sbi/producer/ue_authentication.go
@@ -187,7 +187,12 @@ func UeAuthPostRequestProcedure(updateAuthenticationInfo models.AuthenticationIn
 		Kseaf, err := ueauth.GetKDFValue(KausfDecode, ueauth.FC_FOR_KSEAF_DERIVATION, P0, ueauth.KDFLen(P0))
 		if err != nil {
 			logger.Auth5gAkaComfirmLog.Errorf("GetKDFValue failed: %+v", err)
-			// TODO: return ProblemDetails
+			var problemDetails models.ProblemDetails
+			problemDetails.Title = "Kseaf Derivation Problem"
+			problemDetails.Cause = "KSEAF_DERIVATION_PROBLEM"
+			problemDetails.Detail = err.Error()
+			problemDetails.Status = http.StatusInternalServerError
+			return nil, "", &problemDetails
 		}
 		ausfUeContext.XresStar = authInfoResult.AuthenticationVector.XresStar
 		ausfUeContext.Kausf = Kausf

--- a/internal/sbi/producer/ue_authentication.go
+++ b/internal/sbi/producer/ue_authentication.go
@@ -174,7 +174,12 @@ func UeAuthPostRequestProcedure(updateAuthenticationInfo models.AuthenticationIn
 		var KausfDecode []byte
 		if ausfDecode, err := hex.DecodeString(Kausf); err != nil {
 			logger.Auth5gAkaComfirmLog.Errorf("decode Kausf failed: %+v", err)
-			// TODO: return ProblemDetails
+			var problemDetails models.ProblemDetails
+			problemDetails.Title = "Kausf Decode Problem"
+			problemDetails.Cause = "KAUSF_DECODE_PROBLEM"
+			problemDetails.Detail = err.Error()
+			problemDetails.Status = http.StatusInternalServerError
+			return nil, "", &problemDetails
 		} else {
 			KausfDecode = ausfDecode
 		}

--- a/internal/sbi/producer/ue_authentication.go
+++ b/internal/sbi/producer/ue_authentication.go
@@ -161,7 +161,12 @@ func UeAuthPostRequestProcedure(updateAuthenticationInfo models.AuthenticationIn
 		var hxresStarBytes []byte
 		if bytes, err := hex.DecodeString(concat); err != nil {
 			logger.Auth5gAkaComfirmLog.Errorf("decode concat error: %+v", err)
-			// TODO: return ProblemDetails
+			var problemDetails models.ProblemDetails
+			problemDetails.Title = "Concat Decode Problem"
+			problemDetails.Cause = "CONCAT_DECODE_PROBLEM"
+			problemDetails.Detail = err.Error()
+			problemDetails.Status = http.StatusInternalServerError
+			return nil, "", &problemDetails
 		} else {
 			hxresStarBytes = bytes
 		}


### PR DESCRIPTION
Hello, I am Virgil, a security researcher from the WSPR (Wolfpack Security and Privacy Research) lab at North Carolina State University.

As part of an ongoing 5G security project, we have done some error handling analysis of free5GC. One finding involves the  handling of an error during `hex.DecodeString(Kausf)` on `internal/sbi/producer/ue_authentication.go:175` (Original Line number, updated is 180). An error in this function call results in `Kseaf` being derived from an empty array. This results in a predictable Kseaf value, assuming the adversary knows the snName.

As a Proof-of-Concept, the following code snippet gives me the KSeaf value of `[247 217 81 106 50 180 143 142 179 223 202 133 114 120 163 233 145 78 75 224 236 231 212 69 118 151 63 5 140 250 18 15]` on multiple machines:
```
package main

import (
	"encoding/hex"
	"fmt"

	"github.com/free5gc/openapi/models"
	"github.com/free5gc/util/ueauth"
)

func main() {
	test()
}

func test() (*models.UeAuthenticationCtx, string, *models.ProblemDetails) {
	// Derive Kseaf from Kausf
	Kausf := "abcdefg"
	var KausfDecode []byte
	if ausfDecode, err := hex.DecodeString(Kausf); err != nil {
		//logger.Auth5gAkaComfirmLog.Errorf("decode Kausf failed: %+v", err)
		//var problemDetails models.ProblemDetails
		//problemDetails.Title = "Kausf Decode Problem"
		//problemDetails.Cause = "KAUSF_DECODE_PROBLEM"
		//problemDetails.Detail = err.Error()
		//problemDetails.Status = http.StatusInternalServerError
		//return nil, "", &problemDetails
		fmt.Printf("Err hit")
	} else {
		KausfDecode = ausfDecode
	}
	fmt.Printf("KausfDecode: %+v\n", KausfDecode)
	P0 := []byte("Verizon")
	Kseaf, _ := ueauth.GetKDFValue(KausfDecode, ueauth.FC_FOR_KSEAF_DERIVATION, P0, ueauth.KDFLen(P0))
	fmt.Printf("KSeaf: %+v", Kseaf)
	return nil, "", nil
}
```
The code already contained `// TODO: return ProblemDetails` comments. This PR adds these ProblemDetails returns, as well as the problemDetails returns for the `concat` decode (Line 162) and Kseaf `GetKDFValue` (Line 182, 192 in changed).

Will open submodule hash update PR on main repo if accepted.