### PR TITLE
Feature: Add NRF Consumer support OAuth2

### DIFF
--- a/internal/context/ausf_context_init.go
+++ b/internal/context/ausf_context_init.go
@@ -22,6 +22,10 @@ func InitAusfContext(context *AUSFContext) {
 	context.NfId = uuid.New().String()
 	context.GroupID = configuration.GroupId
 	context.NrfUri = configuration.NrfUri
+	if configuration.NrfCerPem != "" {
+		context.NrfCerPem = configuration.NrfCerPem
+	}
+
 	context.UriScheme = models.UriScheme(configuration.Sbi.Scheme) // default uri scheme
 	context.RegisterIPv4 = factory.AusfSbiDefaultIPv4              // default localhost
 	context.SBIPort = factory.AusfSbiDefaultPort                   // default port

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -19,11 +19,13 @@ type AUSFContext struct {
 	Url                  string
 	UriScheme            models.UriScheme
 	NrfUri               string
+	NrfCerPem            string
 	NfService            map[models.ServiceName]models.NfService
 	PlmnList             []models.PlmnId
 	UdmUeauUrl           string
 	snRegex              *regexp.Regexp
 	EapAkaSupiImsiPrefix bool
+	OAuth2Required       bool
 }
 
 type AusfUeContext struct {

--- a/internal/sbi/consumer/nf_accesstoken.go
+++ b/internal/sbi/consumer/nf_accesstoken.go
@@ -1,0 +1,25 @@
+package consumer
+
+import (
+	"context"
+
+	ausf_context "github.com/free5gc/ausf/internal/context"
+	"github.com/free5gc/ausf/internal/logger"
+	"github.com/free5gc/openapi"
+	"github.com/free5gc/openapi/models"
+	"github.com/free5gc/openapi/oauth"
+)
+
+func GetTokenCtx(scope, targetNF string) (context.Context, *models.ProblemDetails, error) {
+	if ausf_context.GetSelf().OAuth2Required {
+		logger.ConsumerLog.Debugln("GetToekenCtx")
+		ausfSelf := ausf_context.GetSelf()
+		tok, pd, err := oauth.SendAccTokenReq(ausfSelf.NfId, models.NfType_AUSF, scope, targetNF, ausfSelf.NrfUri)
+		if err != nil {
+			return nil, pd, err
+		}
+		return context.WithValue(context.Background(),
+			openapi.ContextOAuth2, tok), pd, nil
+	}
+	return context.TODO(), nil, nil
+}

--- a/internal/sbi/consumer/nf_discovery.go
+++ b/internal/sbi/consumer/nf_discovery.go
@@ -1,7 +1,6 @@
 package consumer
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 
@@ -13,11 +12,16 @@ import (
 func SendSearchNFInstances(nrfUri string, targetNfType, requestNfType models.NfType,
 	param Nnrf_NFDiscovery.SearchNFInstancesParamOpts,
 ) (*models.SearchResult, error) {
+	ctx, _, err := GetTokenCtx("nnrf-disc", "NRF")
+	if err != nil {
+		return nil, err
+	}
+
 	configuration := Nnrf_NFDiscovery.NewConfiguration()
 	configuration.SetBasePath(nrfUri)
 	client := Nnrf_NFDiscovery.NewAPIClient(configuration)
 
-	result, rsp, rspErr := client.NFInstancesStoreApi.SearchNFInstances(context.TODO(),
+	result, rsp, rspErr := client.NFInstancesStoreApi.SearchNFInstances(ctx,
 		targetNfType, requestNfType, &param)
 	if rspErr != nil {
 		return nil, fmt.Errorf("NFInstancesStoreApi Response error: %+w", rspErr)

--- a/internal/sbi/consumer/nf_management.go
+++ b/internal/sbi/consumer/nf_management.go
@@ -34,7 +34,8 @@ func BuildNFInstance(ausfContext *ausf_context.AUSFContext) (profile models.NfPr
 }
 
 // func SendRegisterNFInstance(nrfUri, nfInstanceId string, profile models.NfProfile) (resouceNrfUri string,
-//    retrieveNfInstanceID string, err error) {
+//
+//	retrieveNfInstanceID string, err error) {
 func SendRegisterNFInstance(nrfUri, nfInstanceId string, profile models.NfProfile) (string, string, error) {
 	configuration := Nnrf_NFManagement.NewConfiguration()
 	configuration.SetBasePath(nrfUri)
@@ -42,8 +43,8 @@ func SendRegisterNFInstance(nrfUri, nfInstanceId string, profile models.NfProfil
 
 	var res *http.Response
 	for {
-		if _, resTmp, err := client.NFInstanceIDDocumentApi.RegisterNFInstance(context.TODO(), nfInstanceId,
-			profile); err != nil || resTmp == nil {
+		nf, resTmp, err := client.NFInstanceIDDocumentApi.RegisterNFInstance(context.TODO(), nfInstanceId, profile)
+		if err != nil || resTmp == nil {
 			logger.ConsumerLog.Errorf("AUSF register to NRF Error[%v]", err)
 			time.Sleep(2 * time.Second)
 			continue
@@ -64,6 +65,14 @@ func SendRegisterNFInstance(nrfUri, nfInstanceId string, profile models.NfProfil
 			resourceUri := res.Header.Get("Location")
 			resourceNrfUri := resourceUri[:strings.Index(resourceUri, "/nnrf-nfm/")]
 			retrieveNfInstanceID := resourceUri[strings.LastIndex(resourceUri, "/")+1:]
+
+			oauth2 := nf.CustomInfo["oauth2"].(bool)
+			ausf_context.GetSelf().OAuth2Required = oauth2
+			logger.MainLog.Infoln("OAuth2 setting receive from NRF:", oauth2)
+			if oauth2 && ausf_context.GetSelf().NrfCerPem == "" {
+				logger.CfgLog.Error("OAuth2 enable but no nrfCerPem provided in config.")
+			}
+
 			return resourceNrfUri, retrieveNfInstanceID, nil
 		} else {
 			fmt.Println(fmt.Errorf("handler returned wrong status code %d", status))
@@ -76,13 +85,18 @@ func SendRegisterNFInstance(nrfUri, nfInstanceId string, profile models.NfProfil
 func SendDeregisterNFInstance() (*models.ProblemDetails, error) {
 	logger.ConsumerLog.Infof("Send Deregister NFInstance")
 
+	ctx, pd, err := GetTokenCtx("nnrf-nfm", "NRF")
+	if err != nil {
+		return pd, err
+	}
+
 	ausfSelf := ausf_context.GetSelf()
 	// Set client and set url
 	configuration := Nnrf_NFManagement.NewConfiguration()
 	configuration.SetBasePath(ausfSelf.NrfUri)
 	client := Nnrf_NFManagement.NewAPIClient(configuration)
 
-	res, err := client.NFInstanceIDDocumentApi.DeregisterNFInstance(context.Background(), ausfSelf.NfId)
+	res, err := client.NFInstanceIDDocumentApi.DeregisterNFInstance(ctx, ausfSelf.NfId)
 	if err == nil {
 		return nil, err
 	} else if res != nil {

--- a/internal/sbi/producer/functions.go
+++ b/internal/sbi/producer/functions.go
@@ -135,7 +135,8 @@ func EapEncodeAttribute(attributeType string, data string) (string, error) {
 }
 
 // func eapAkaPrimePrf(ikPrime string, ckPrime string, identity string) (K_encr string, K_aut string, K_re string,
-//    MSK string, EMSK string) {
+//
+//	MSK string, EMSK string) {
 func eapAkaPrimePrf(ikPrime string, ckPrime string, identity string) ([]byte, []byte, []byte, []byte, []byte) {
 	keyAp := ikPrime + ckPrime
 

--- a/internal/sbi/producer/ue_authentication.go
+++ b/internal/sbi/producer/ue_authentication.go
@@ -82,7 +82,8 @@ func HandleUeAuthPostRequest(request *httpwrapper.Request) *httpwrapper.Response
 }
 
 // func UeAuthPostRequestProcedure(updateAuthenticationInfo models.AuthenticationInfo) (
-//    response *models.UeAuthenticationCtx, locationURI string, problemDetails *models.ProblemDetails) {
+//
+//	response *models.UeAuthenticationCtx, locationURI string, problemDetails *models.ProblemDetails) {
 func UeAuthPostRequestProcedure(updateAuthenticationInfo models.AuthenticationInfo) (*models.UeAuthenticationCtx,
 	string, *models.ProblemDetails,
 ) {

--- a/pkg/factory/config.go
+++ b/pkg/factory/config.go
@@ -57,6 +57,7 @@ type Configuration struct {
 	Sbi                  *Sbi            `yaml:"sbi,omitempty" valid:"required"`
 	ServiceNameList      []string        `yaml:"serviceNameList,omitempty" valid:"required"`
 	NrfUri               string          `yaml:"nrfUri,omitempty" valid:"url,required"`
+	NrfCerPem            string          `yaml:"nrfCerPem,omitempty" valid:"type(string),minstringlength(1),optional"`
 	PlmnSupportList      []models.PlmnId `yaml:"plmnSupportList,omitempty" valid:"required"`
 	GroupId              string          `yaml:"groupId,omitempty" valid:"type(string),minstringlength(1)"`
 	EapAkaSupiImsiPrefix bool            `yaml:"eapAkaSupiImsiPrefix,omitempty" valid:"type(bool),optional"`


### PR DESCRIPTION
## Description

This pull request enables AUSF to use NRF services through the OAuth2 service authorization.

## Note
Config must add ```nrfCerPem``` 
```yaml
configuration:
  nrfCerPem: cert/nrf.pem # NRF Certificate
```