### PR TITLE
fix: SendAuthResultToUDM

### DIFF
--- a/internal/sbi/processor/ue_authentication.go
+++ b/internal/sbi/processor/ue_authentication.go
@@ -176,7 +176,7 @@ func (p *Processor) EapAuthComfirmRequestProcedure(
 
 	if !eapOK {
 		logger.AuthELog.Warnf("EAP-AKA' failure: %s", eapErrStr)
-		if sendErr := p.Consumer().SendAuthResultToUDM(eapSessionID, models.UdmUeauAuthType_EAP_AKA_PRIME,
+		if sendErr := p.Consumer().SendAuthResultToUDM(currentSupi, models.UdmUeauAuthType_EAP_AKA_PRIME,
 			false, servingNetworkName, ausfCurrentContext.UdmUeauUrl); sendErr != nil {
 			logger.AuthELog.Infoln(sendErr.Error())
 			problemDetails := models.ProblemDetails{
@@ -198,7 +198,7 @@ func (p *Processor) EapAuthComfirmRequestProcedure(
 		eapSession.Links = make(map[string][]models.Link)
 		eapSession.Links["eap-session"] = []models.Link{linksValue}
 	} else if ausfCurrentContext.AuthStatus == models.AusfUeAuthenticationAuthResult_FAILURE {
-		if sendErr := p.Consumer().SendAuthResultToUDM(eapSessionID, models.UdmUeauAuthType_EAP_AKA_PRIME, false,
+		if sendErr := p.Consumer().SendAuthResultToUDM(currentSupi, models.UdmUeauAuthType_EAP_AKA_PRIME, false,
 			servingNetworkName, ausfCurrentContext.UdmUeauUrl); sendErr != nil {
 			logger.AuthELog.Infoln(sendErr.Error())
 			var problemDetails models.ProblemDetails

--- a/internal/sbi/processor/ue_authentication.go
+++ b/internal/sbi/processor/ue_authentication.go
@@ -127,7 +127,7 @@ func (p *Processor) EapAuthComfirmRequestProcedure(
 				eapSession.EapPayload = eapSuccPkt
 				udmUrl := ausfCurrentContext.UdmUeauUrl
 				if sendErr := p.Consumer().SendAuthResultToUDM(
-					eapSessionID,
+					currentSupi,
 					models.UdmUeauAuthType_EAP_AKA_PRIME,
 					true,
 					servingNetworkName,


### PR DESCRIPTION
**What bug it fixes**
SendAuthResultToUDM should identify the UE using the SUPI so that UDM can correctly associate and store/process the authentication result for the right subscriber.

**Using eapSessionID (a session identifier) instead of currentSupi could cause:**

UDM not being able to find the correct UE/subscriber record
the authentication result update failing or being applied incorrectly
This PR ensures that when EAP-AKA' authentication fails, AUSF reports the result to UDM using the correct UE identity (currentSupi).
