### PR TITLE
fix: preserve UDM error status in GenerateAuthData

### DIFF
--- a/internal/sbi/consumer/udm_service.go
+++ b/internal/sbi/consumer/udm_service.go
@@ -85,12 +85,12 @@ func (s *nudmService) GenerateAuthDataApi(
 	udmUrl string,
 	supiOrSuci string,
 	authInfoReq models.AuthenticationInfoRequest,
-) (*models.UdmUeauAuthenticationInfoResult, *models.ProblemDetails, error) {
+) (*models.UdmUeauAuthenticationInfoResult, error) {
 	client := s.getUdmUeauClient(udmUrl)
 
-	ctx, pd, err := ausf_context.GetSelf().GetTokenCtx(models.ServiceName_NUDM_UEAU, models.NrfNfManagementNfType_UDM)
+	ctx, _, err := ausf_context.GetSelf().GetTokenCtx(models.ServiceName_NUDM_UEAU, models.NrfNfManagementNfType_UDM)
 	if err != nil {
-		return nil, pd, err
+		return nil, err
 	}
 
 	udmAuthInfoReq := models.UdmUeauAuthenticationInfoRequest{
@@ -109,17 +109,9 @@ func (s *nudmService) GenerateAuthDataApi(
 
 	rsp, err := client.GenerateAuthDataApi.GenerateAuthData(ctx, request)
 	if err != nil {
-		var problemDetails models.ProblemDetails
-		if rsp == nil {
-			problemDetails.Cause = "NO_RESPONSE_FROM_SERVER"
-		} else if rsp.UdmUeauAuthenticationInfoResult.AuthenticationVector == nil {
-			problemDetails.Cause = "AV_GENERATION_PROBLEM"
-		} else {
-			problemDetails.Cause = "UPSTREAM_SERVER_ERROR"
-		}
-		return nil, &problemDetails, err
+		return nil, err
 	}
 	authInfoResult := rsp.UdmUeauAuthenticationInfoResult
 
-	return &authInfoResult, nil, nil
+	return &authInfoResult, nil
 }

--- a/internal/sbi/processor/ue_authentication.go
+++ b/internal/sbi/processor/ue_authentication.go
@@ -23,7 +23,9 @@ import (
 	ausf_context "github.com/free5gc/ausf/internal/context"
 	"github.com/free5gc/ausf/internal/logger"
 	"github.com/free5gc/ausf/pkg/factory"
+	"github.com/free5gc/openapi"
 	"github.com/free5gc/openapi/models"
+	Nudm_UEAuthentication "github.com/free5gc/openapi/udm/UEAuthentication"
 	"github.com/free5gc/util/metrics/sbi"
 	"github.com/free5gc/util/ueauth"
 )
@@ -274,13 +276,22 @@ func (p *Processor) UeAuthPostRequestProcedure(c *gin.Context, updateAuthenticat
 
 	udmUrl := p.Consumer().GetUdmUrl(self.NrfUri)
 
-	result, pd, err := p.Consumer().GenerateAuthDataApi(udmUrl, supiOrSuci, authInfoReq)
+	result, err := p.Consumer().GenerateAuthDataApi(udmUrl, supiOrSuci, authInfoReq)
 	if err != nil {
-		logger.UeAuthLog.Infof("GenerateAuthDataApi error: %+v", err)
-		c.Set(sbi.IN_PB_DETAILS_CTX_STR, pd.Cause)
-		c.JSON(http.StatusInternalServerError, pd)
+		if apiErr, ok := err.(openapi.GenericOpenAPIError); ok {
+			if genAuthDataErr, ok2 := apiErr.Model().(Nudm_UEAuthentication.GenerateAuthDataError); ok2 {
+				problem := genAuthDataErr.ProblemDetails
+				c.Set(sbi.IN_PB_DETAILS_CTX_STR, problem.Cause)
+				c.JSON(int(problem.Status), problem)
+				return
+			}
+		}
+		problemDetails := openapi.ProblemDetailsSystemFailure(err.Error())
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, problemDetails.Cause)
+		c.JSON(int(problemDetails.Status), problemDetails)
 		return
 	}
+
 	authInfoResult := *result
 
 	ueid := authInfoResult.Supi


### PR DESCRIPTION
This is for issue#[955](https://github.com/free5gc/free5gc/issues/955)