### PR TITLE
fix: check for nil EAP content to prevent panic on malformed payload

### DIFF
--- a/internal/sbi/processor/ue_authentication.go
+++ b/internal/sbi/processor/ue_authentication.go
@@ -92,7 +92,10 @@ func (p *Processor) EapAuthComfirmRequestProcedure(
 	eapOK := true
 	var eapErrStr string
 
-	if eapContent.Code != layers.EAPCodeResponse {
+	if eapContent == nil {
+		eapOK = false
+		eapErrStr = "failed to parse EAP packet"
+	} else if eapContent.Code != layers.EAPCodeResponse {
 		eapOK = false
 		eapErrStr = "eap packet code error"
 	} else if eapContent.Type != ausf_context.EAP_AKA_PRIME_TYPENUM {


### PR DESCRIPTION
## Security Fix

Fixes free5gc/free5gc#981

### Vulnerability

`EapAuthComfirmRequestProcedure()` dereferences `eapContent.Code` without a nil check:

```go
eapContent, _ := eapLayer.(*layers.EAP)  // nil if parsing fails
if eapContent.Code != layers.EAPCodeResponse {  // PANIC
```

A remote attacker can crash the AUSF by sending an AuthenticationResponse with a malformed EAP payload during EAP-AKA' authentication. No subscriber keys required.

### Fix

Add a nil check before field access:

```go
if eapContent == nil {
    eapOK = false
    eapErrStr = "failed to parse EAP packet"
} else if eapContent.Code != layers.EAPCodeResponse {
```