### PR TITLE
fix(sbi/processor): bounds-check decodeEapAkaPrime against truncated EAP packets

### DIFF
--- a/internal/sbi/processor/ue_authentication.go
+++ b/internal/sbi/processor/ue_authentication.go
@@ -713,12 +713,26 @@ func decodeEapAkaPrime(eapPkt []byte) (*ausf_context.EapAkaPrimePkt, error) {
 	var attrLen int
 	var decodeAttr ausf_context.EapAkaPrimeAttribute
 	attributes := make(map[uint8]ausf_context.EapAkaPrimeAttribute)
+	// A well-formed EAP-AKA' packet has at least a 5-byte EAP header plus
+	// a 1-byte Subtype plus 2 reserved bytes (RFC 5448 §3) before the
+	// attribute TLVs begin at offset 3. A crafted NAS AuthenticationResponse
+	// carrying a 5-byte EAP payload (type field only) made eapPkt[5:] an
+	// empty slice and data[0] panicked (free5gc/free5gc#982).
+	if len(eapPkt) < 6 {
+		return nil, fmt.Errorf("EAP-AKA' packet too short: got %d bytes, need at least 6", len(eapPkt))
+	}
 	data := eapPkt[5:]
 	decodePkt.Subtype = data[0]
 	dataLen := len(data)
 
 	// decode attributes
 	for i := 3; i < dataLen; i += attrLen {
+		// Each attribute is a 2-byte header (type, length/4) followed by
+		// value bytes. Reject truncated headers instead of letting
+		// data[i+1] run off the end (free5gc/free5gc#983).
+		if i+1 >= dataLen {
+			return nil, fmt.Errorf("EAP-AKA' attribute header truncated at offset %d", i)
+		}
 		attrType := data[i]
 		attrLen = int(data[i+1]) * 4
 		if attrLen == 0 {

--- a/internal/sbi/processor/ue_authentication.go
+++ b/internal/sbi/processor/ue_authentication.go
@@ -713,11 +713,7 @@ func decodeEapAkaPrime(eapPkt []byte) (*ausf_context.EapAkaPrimePkt, error) {
 	var attrLen int
 	var decodeAttr ausf_context.EapAkaPrimeAttribute
 	attributes := make(map[uint8]ausf_context.EapAkaPrimeAttribute)
-	// A well-formed EAP-AKA' packet has at least a 5-byte EAP header plus
-	// a 1-byte Subtype plus 2 reserved bytes (RFC 5448 §3) before the
-	// attribute TLVs begin at offset 3. A crafted NAS AuthenticationResponse
-	// carrying a 5-byte EAP payload (type field only) made eapPkt[5:] an
-	// empty slice and data[0] panicked (free5gc/free5gc#982).
+	// Bounds-check the EAP header before slicing.
 	if len(eapPkt) < 6 {
 		return nil, fmt.Errorf("EAP-AKA' packet too short: got %d bytes, need at least 6", len(eapPkt))
 	}
@@ -727,9 +723,7 @@ func decodeEapAkaPrime(eapPkt []byte) (*ausf_context.EapAkaPrimePkt, error) {
 
 	// decode attributes
 	for i := 3; i < dataLen; i += attrLen {
-		// Each attribute is a 2-byte header (type, length/4) followed by
-		// value bytes. Reject truncated headers instead of letting
-		// data[i+1] run off the end (free5gc/free5gc#983).
+		// Bounds-check the 2-byte attribute header.
 		if i+1 >= dataLen {
 			return nil, fmt.Errorf("EAP-AKA' attribute header truncated at offset %d", i)
 		}


### PR DESCRIPTION
## Summary

`decodeEapAkaPrime` did two unbounded slice reads:

1. `data := eapPkt[5:]` + `decodePkt.Subtype = data[0]` — no check that `len(eapPkt) >= 6`.
2. `attrLen = int(data[i+1]) * 4` in the attribute loop — no check that `i+1 < dataLen`.

An authenticated attacker that triggers EAP-AKA' auth can send a NAS `AuthenticationResponse` carrying a 5-byte EAP payload (type field only). `eapPkt[5:]` is an empty slice, `data[0]` panics with index-out-of-range, and the AUSF goroutine dies. Truncating an attribute header to 1 byte produces the same class of panic at `data[i+1]`.

## Fix

- Reject EAP-AKA' packets shorter than 6 bytes before slicing, returning a descriptive error.
- Short-circuit the attribute loop when the 2-byte TLV header would run past the end of `data`.

AUSF now returns a clean error response to AMF instead of panicking.

Fixes free5gc/free5gc#982 (`data[0]` panic) and free5gc/free5gc#983 (`data[i+1]` panic).

## Test

- `go build ./...` green.
- `gofmt` clean.
- Package has no existing tests, so no regressions.

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>
