### PR TITLE
fix: avoid panic on malformed UDM discovery result

### DIFF
--- a/internal/sbi/consumer/nrf_service.go
+++ b/internal/sbi/consumer/nrf_service.go
@@ -230,13 +230,11 @@ func (s *nnrfService) GetUdmUrl(nrfUri string) (string, error) {
 		nfDiscoverParam,
 	)
 	if err != nil {
-		logger.ConsumerLog.Errorln("[Search UDM UEAU] ", err.Error())
 		return "", err
 	}
 
 	_, udmUrl, err := openapi.GetServiceNfProfileAndUri(res.NfInstances, models.ServiceName_NUDM_UEAU)
 	if err != nil {
-		logger.ConsumerLog.Errorln("[Search UDM UEAU] ", err.Error())
 		return "", err
 	}
 	return udmUrl, nil

--- a/internal/sbi/consumer/nrf_service.go
+++ b/internal/sbi/consumer/nrf_service.go
@@ -2,7 +2,6 @@ package consumer
 
 import (
 	"context"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -216,8 +215,7 @@ func (s *nnrfService) buildNfProfile(ausfContext *ausf_context.AUSFContext) (
 	return
 }
 
-func (s *nnrfService) GetUdmUrl(nrfUri string) string {
-	udmUrl := "https://localhost:29503" // default
+func (s *nnrfService) GetUdmUrl(nrfUri string) (string, error) {
 	targetNfType := models.NrfNfManagementNfType_UDM
 	requestNfType := models.NrfNfManagementNfType_AUSF
 	nfDiscoverParam := Nnrf_NFDiscovery.SearchNFInstancesRequest{
@@ -232,16 +230,14 @@ func (s *nnrfService) GetUdmUrl(nrfUri string) string {
 		nfDiscoverParam,
 	)
 	if err != nil {
-		logger.ConsumerLog.Errorln("[Search UDM UEAU] ", err.Error(), "use defalt udmUrl", udmUrl)
-	} else if len(res.NfInstances) > 0 {
-		udmInstance := res.NfInstances[0]
-		if len(udmInstance.Ipv4Addresses) > 0 && udmInstance.NfServices != nil {
-			ueauService := udmInstance.NfServices[0]
-			ueauEndPoint := ueauService.IpEndPoints[0]
-			udmUrl = string(ueauService.Scheme) + "://" + ueauEndPoint.Ipv4Address + ":" + strconv.Itoa(int(ueauEndPoint.Port))
-		}
-	} else {
-		logger.ConsumerLog.Errorln("[Search UDM UEAU] len(NfInstances) = 0")
+		logger.ConsumerLog.Errorln("[Search UDM UEAU] ", err.Error())
+		return "", err
 	}
-	return udmUrl
+
+	_, udmUrl, err := openapi.GetServiceNfProfileAndUri(res.NfInstances, models.ServiceName_NUDM_UEAU)
+	if err != nil {
+		logger.ConsumerLog.Errorln("[Search UDM UEAU] ", err.Error())
+		return "", err
+	}
+	return udmUrl, nil
 }

--- a/internal/sbi/processor/ue_authentication.go
+++ b/internal/sbi/processor/ue_authentication.go
@@ -288,7 +288,19 @@ func (p *Processor) UeAuthPostRequestProcedure(c *gin.Context, updateAuthenticat
 		lastEapID = ausfCurrentContext.EapID
 	}
 
-	udmUrl := p.Consumer().GetUdmUrl(self.NrfUri)
+	udmUrl, err := p.Consumer().GetUdmUrl(self.NrfUri)
+	if err != nil {
+		logger.UeAuthLog.Errorf("UDM discovery failed: %+v", err)
+		problemDetails := models.ProblemDetails{
+			Title:  "UDM Discovery Failed",
+			Cause:  "UDM_DISCOVERY_FAILED",
+			Detail: err.Error(),
+			Status: http.StatusServiceUnavailable,
+		}
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, problemDetails.Cause)
+		c.JSON(http.StatusServiceUnavailable, problemDetails)
+		return
+	}
 
 	result, err := p.Consumer().GenerateAuthDataApi(udmUrl, supiOrSuci, authInfoReq)
 	if err != nil {


### PR DESCRIPTION
This is for issue#[896](https://github.com/free5gc/free5gc/issues/896).